### PR TITLE
use getpref/setpref functions in user_string.m

### DIFF
--- a/ghostscript.m
+++ b/ghostscript.m
@@ -141,7 +141,8 @@ if ~good
 end
 % Update the current default path to the path found
 if ~user_string('ghostscript', path_)
-    warning('Path to ghostscript installation could not be saved. Enter it manually in %s.', fullfile(fileparts(which('user_string.m')), '.ignore', 'ghostscript.txt'));
+    warning(['Path to ghostscript installation could not be persisted.\n' ...
+        'Check that you have write access to the preferences folder %s.'], prefdir);
     return
 end
 return

--- a/pdftops.m
+++ b/pdftops.m
@@ -94,7 +94,8 @@ if ~good
 end
 % Update the current default path to the path found
 if ~user_string('pdftops', path_)
-    warning('Path to pdftops executable could not be saved. Enter it manually in %s.', fullfile(fileparts(which('user_string.m')), '.ignore', 'pdftops.txt'));
+    warning(['Path to pdftops executable could not be persisted.\n' ...
+        'Check that you have write access to the preferences folder %s'], prefdir);
     return
 end
 return

--- a/user_string.m
+++ b/user_string.m
@@ -4,13 +4,11 @@
 %   string = user_string(string_name)
 %   saved = user_string(string_name, new_string)
 %
-% Function to get and set a string in a system or user specific file. This
+% Function to get and set a string persisted in user preferences. This
 % enables, for example, system specific paths to binaries to be saved.
 %
 % IN:
-%   string_name - String containing the name of the string required. The
-%                 string is extracted from a file called (string_name).txt,
-%                 stored in the same directory as user_string.m.
+%   string_name - String containing the name of the string required.
 %   new_string - The new string to be saved under the name given by
 %                string_name.
 %
@@ -20,68 +18,33 @@
 
 % Copyright (C) Oliver Woodford 2011-2013
 
-% This method of saving paths avoids changing .m files which might be in a
-% version control system. Instead it saves the user dependent paths in
-% separate files with a .txt extension, which need not be checked in to
-% the version control system. Thank you to Jonas Dorn for suggesting this
-% approach.
-
-% 10/01/2013 - Access files in text, not binary mode, as latter can cause
-% errors. Thanks to Christian for pointing this out.
+% 2014-04-24 - Rewrote function to use getpref/setpref.
 
 function string = user_string(string_name, string)
-if ~ischar(string_name)
-    error('string_name must be a string.');
+% validate arguments
+if ~isvarname(string_name)
+    error('Invalid key.');
 end
-% Create the full filename
-string_name = fullfile(fileparts(mfilename('fullpath')), '.ignore', [string_name '.txt']);
-if nargin > 1
-    % Set string
-    if ~ischar(string)
-        error('new_string must be a string.');
-    end
-    % Make sure the save directory exists
-    dname = fileparts(string_name);
-    if ~exist(dname, 'dir')
-        % Create the directory
-        try
-            if ~mkdir(dname)                
-                string = false;
-                return
-            end
-        catch
-            string = false;
-            return
-        end
-        % Make it hidden
-        try
-            fileattrib(dname, '+h');
-        catch
-        end
-    end
-    % Write the file
-    fid = fopen(string_name, 'wt');
-    if fid == -1
-        string = false;
-        return
-    end
-    try
-        fprintf(fid, '%s', string);
-    catch
-        fclose(fid);
-        string = false;
-        return
-    end
-    fclose(fid);
-    string = true;
+if nargin > 1 && ~ischar(string)
+    error('Value must be a string.');
+end
+
+% get/set preference value
+group_name = 'ojwoodford_export_fig';
+if nargin < 2
+    % get value
+    string = getpref(group_name, string_name, '');
 else
-    % Get string
-    fid = fopen(string_name, 'rt');
-    if fid == -1
-        string = '';
-        return
+    % set value
+    try
+        if ~ispref(group_name, string_name)
+            addpref(group_name, string_name, string);
+        else
+            setpref(group_name, string_name, string);
+        end
+        string = true;    % success
+    catch
+        string = false;   % failure
     end
-    string = fgetl(fid);
-    fclose(fid);
 end
-return
+end


### PR DESCRIPTION
Use [getpref](http://www.mathworks.com/help/matlab/ref/getpref.html)/[setpref](http://www.mathworks.com/help/matlab/ref/setpref.html)/[addpref](http://www.mathworks.com/help/matlab/ref/addpref.html)/[ispref](http://www.mathworks.com/help/matlab/ref/ispref.html) family of functions instead of manually maintaining preferences in text files.

Internally those functions persist values to a MAT-file at `fullfile(prefdir,'matlabprefs.mat'))`.
