### PR TITLE
Fixed the bug when exporing with axes handles instead of figure handles

### DIFF
--- a/export_fig.m
+++ b/export_fig.m
@@ -579,7 +579,11 @@ end
 
 % Set default anti-aliasing now we know the renderer
 if options.aa_factor == 0
-    options.aa_factor = 1 + 2 * (~(using_hg2(fig) && strcmp(get(fig, 'GraphicsSmoothing'), 'on')) | (options.renderer == 3));
+    if strcmp(get(fig,'type'),'figure')
+        options.aa_factor = 1 + 2 * (~(using_hg2(fig) && strcmp(get(fig, 'GraphicsSmoothing'), 'on')) | (options.renderer == 3));
+    else
+        options.aa_factor = 1 + 2 * (~(using_hg2(fig)) | (options.renderer == 3));
+    end
 end
 
 % Convert user dir '~' to full path


### PR DESCRIPTION
Fixed a bug occurring when using export_fig on axes handle for which the property `GraphicsSmoothing` does not exist.
