### PR TITLE
Reduce memory usage in im2gif.

### DIFF
--- a/im2gif.m
+++ b/im2gif.m
@@ -53,8 +53,15 @@ end
 
 % Convert to indexed image
 [h, w, c, n] = size(A);
+
+uns = cell(1,size(A,4));
+for nn=1:size(A,4)
+    uns{nn}=unique(reshape(A(:,:,:,nn), h*w, c),'rows');
+end
+map=unique(cell2mat(uns'),'rows');
+
 A = reshape(permute(A, [1 2 4 3]), h, w*n, c);
-map = unique(reshape(A, h*w*n, c), 'rows');
+
 if size(map, 1) > 256
     dither_str = {'dither', 'nodither'};
     dither_str = dither_str{1+(options.dither==0)};


### PR DESCRIPTION
The use of unique(A,'rows') on the whole image stack at once causes massive memory usage when dealing with large images (Matlab 2017b). Running unique() on individual frames, then again on the results, drastically reduces the memory usage and slightly improves the execution time.