### PR TITLE
Addition to handle greyscale images in im2gif

### DIFF
--- a/im2gif.m
+++ b/im2gif.m
@@ -183,6 +183,8 @@ switch lower(info(1).Format)
                 A{a} = 255 - A{a};
                 A{a}(:,:,4) = A{a}(:,:,4) / 255;
                 A{a} = uint8(A(:,:,1:3) .* A{a}(:,:,[4 4 4]));
+            elseif
+                A{a} = cat(3, A{a}, A{a}, A{a});
             end
         end
         A = cat(4, A{:});

--- a/im2gif.m
+++ b/im2gif.m
@@ -183,7 +183,8 @@ switch lower(info(1).Format)
                 A{a} = 255 - A{a};
                 A{a}(:,:,4) = A{a}(:,:,4) / 255;
                 A{a} = uint8(A(:,:,1:3) .* A{a}(:,:,[4 4 4]));
-            elseif size(A{a}, 3) < 3
+            elseif size(A{a}, 3) < 3 %Check whether TIFF has been read in as greyscale
+                %Convert from greyscale to RGB colorspace
                 A{a} = cat(3, A{a}, A{a}, A{a});
             end
         end

--- a/im2gif.m
+++ b/im2gif.m
@@ -183,7 +183,7 @@ switch lower(info(1).Format)
                 A{a} = 255 - A{a};
                 A{a}(:,:,4) = A{a}(:,:,4) / 255;
                 A{a} = uint8(A(:,:,1:3) .* A{a}(:,:,[4 4 4]));
-            elseif
+            elseif size(A{a}, 3) < 3
                 A{a} = cat(3, A{a}, A{a}, A{a});
             end
         end


### PR DESCRIPTION
I ran into an issue the other day using _im2gif_ when creating a gif where some of the images in the tiff were RGB and several others used only greyscale colors (even though they were made and saved in the RGB colorspace).

_imread_ was reading them in as a 2d matrix and causing a mismatch with the 3d matricies from the RGB images. I added a few lines of code to the if statement that checks for CMYK tiffs to also check for greyscale and convert accordingly.

I'm not sure that my code is the most efficient solution, but it works. If _im2gif_ requires it to be RGB anyway, I don't see any reason no to automatically handle greyscale as it is read in.