### PR TITLE
export_fig is working in it's folder but not in the other folder trough added path in matlab 2014a, Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.ignore
+.DS_store
 *.txt
 *.asv
 *~


### PR DESCRIPTION
I got following error when calling export_fig through the added path, when the working directory is different than the folder containing it.

export_fig error. Please ensure:
  that you are using the latest version of export_fig
  and that you have Ghostscript installed
  and that you have pdftops installed
  and that you do not have multiple versions of export_fig installed by mistake
  and that you did not made a mistake in the expected input arguments

If the problem persists, then please report a new issue.

Error using fix_lines
Too many output arguments.

Error in print2eps (line 497)
        fstrm = fix_lines(fstrm);

Error in export_fig (line 808)
                print2eps(tmp_nam, fig, options, printArgs{:});

Error in plot_results1 (line 38)
    export_fig(strcat(dirAddress,figname,'expo'),'-png','.eps','-pdf','-transparent','-painters'); 