### PR TITLE
Fix Ghostscript detection for MiKTeX installations on Windows

### DIFF
--- a/ghostscript.m
+++ b/ghostscript.m
@@ -86,7 +86,7 @@ function path_ = gs_path
     end
     % Check whether the binary is on the path
     if ispc
-        bin = {'gswin32c.exe', 'gswin64c.exe', 'gs'};
+        bin = {'gswin32c.exe', 'gswin64c.exe', 'gs', 'mgs'};
     else
         bin = {'gs'};
     end


### PR DESCRIPTION
## Summary
Fixes Ghostscript detection on Windows when installed via MiKTeX.

## Problem
The current code only checks for `gswin32c.exe` and `gswin64c.exe`, but MiKTeX installs Ghostscript as `mgs.exe`.

## Solution
- Added `mgs.exe` 

## Testing
- [x] Tested on Windows with MiKTeX installation
- [x] Verified existing functionality still works