### PR TITLE
Fix small documentation typos

### DIFF
--- a/eps2pdf.m
+++ b/eps2pdf.m
@@ -155,7 +155,7 @@ function eps2pdf(source, dest, crop, append, gray, quality, gs_options) %#ok<*RG
             % The output pdf should now be in dest
 
             % If the returned message is non-empty, a possible error may have
-            % occured, so check the file size to ensure whether the file grew
+            % occurred, so check the file size to ensure whether the file grew
             if ~isempty(message) && ~isempty(orig_bytes)
                 file_info = dir(dest);
                 new_bytes = file_info.bytes;

--- a/pdftops.m
+++ b/pdftops.m
@@ -92,7 +92,7 @@ function path_ = xpdf_path
         errMsg = {errMsg1,errMsg2};
     else
         % Provide an alternative possible explanation as per issue #137
-        errMsg2 = 'If pdftops is installed, maybe Matlab is shaddowing it, as described in ';
+        errMsg2 = 'If pdftops is installed, maybe Matlab is shadowing it, as described in ';
         url2 = 'https://github.com/altmany/export_fig/issues/137';
         fprintf(2, '%s%s\n', errMsg2, hyperlink(url2,'issue #137'));
         errMsg2 = [errMsg2 url2];

--- a/print2array.m
+++ b/print2array.m
@@ -15,7 +15,7 @@ function [A, bcol, alpha] = print2array(fig, res, renderer, gs_options)
 % If the Java screen-capture fails or if resolution~=1, the builtin print()
 % function is used to create a temp TIF file, which is then loaded and reported.
 % If this fails, print() is used to create a temp EPS file which is converted to
-% a TIF file using Ghostcript (http://www.ghostscript.com), loaded and reported.
+% a TIF file using Ghostscript (http://www.ghostscript.com), loaded and reported.
 %
 % Inputs:
 %   figure_handle - The handle of the figure to be exported. Default: gcf.


### PR DESCRIPTION
Summary
- Fix a spelling typo in the pdftops fallback message.
- Fix two spelling typos in comments/help text.

Validation
- git diff --check

This is documentation/message text only; I did not run the MATLAB test suite.